### PR TITLE
Vertex information updates 08/05/23

### DIFF
--- a/NtupleProcessor/include/EventAnalyzer.hh
+++ b/NtupleProcessor/include/EventAnalyzer.hh
@@ -93,6 +93,7 @@ class EventAnalyzer
 
     MC_QQbar      _mc      ;
     Jet_QQbar     _jet     ;
+    VTX_QQbar     _vtx     ;
     PFO_QQbar     _pfo     ;
     Branch_QQbar  _branch  ;
 

--- a/NtupleProcessor/include/TreeReader.hh
+++ b/NtupleProcessor/include/TreeReader.hh
@@ -20,6 +20,7 @@ class TreeReader
 
     void InitializeMCReadTree (TTree *tree, MC_QQbar & _data,  Branch_QQbar & _branch);
     void InitializeJetReadTree(TTree *tree, Jet_QQbar & _data, Branch_QQbar & _branch);
+    void InitializeVTXReadTree(TTree *tree, VTX_QQbar & _data, Branch_QQbar & _branch);
     void InitializePFOReadTree(TTree *tree, PFO_QQbar & _data, Branch_QQbar & _branch);
 
   private: 

--- a/NtupleProcessor/src/EventAnalyzer.cc
+++ b/NtupleProcessor/src/EventAnalyzer.cc
@@ -289,21 +289,21 @@ void EventAnalyzer::AnalyzeReco(Long64_t entry)
 
   _hm.h_tagging[_hm.jets_info]->Fill(0);
 
-  if(_pfo.pfo_n_j1 == 2 and _pfo.pfo_n_j2 == 2) {
+  if(_jet.jet_npfo[0] == 2 and _jet.jet_npfo[1] == 2) {
     _hm.h_tagging[_hm.jets_info]->Fill(6);
   }
-  if(_pfo.pfo_n_j1 == 1 and _pfo.pfo_n_j2 == 1) {
+  if(_jet.jet_npfo[0] == 1 and _jet.jet_npfo[1] == 1) {
     _hm.h_tagging[_hm.jets_info]->Fill(7);
   }
 
   // with SV
-  if (_pfo.jet_nvtx_j1 == 2) {
+  if (_jet.jet_nvtx[0] == 2) {
     _hm.h_tagging[_hm.s_ctag]->Fill(_jet.jet_ctag[0]);
     _hm.h_tagging[_hm.s_btag]->Fill(_jet.jet_btag[0]);
     _hm.h_tagging[_hm.jets_info]->Fill(1);
     _hm.h_tagging[_hm.jets_info]->Fill(4);
   }
-  if (_pfo.jet_nvtx_j2 == 2) {
+  if (_jet.jet_nvtx[1] == 2) {
     _hm.h_tagging[_hm.s_ctag]->Fill(_jet.jet_ctag[1]);
     _hm.h_tagging[_hm.s_btag]->Fill(_jet.jet_btag[1]);
     _hm.h_tagging[_hm.jets_info]->Fill(2);
@@ -311,13 +311,13 @@ void EventAnalyzer::AnalyzeReco(Long64_t entry)
   }
 
   // w/o SV
-  if (_pfo.jet_nvtx_j1 == 1) {
+  if (_jet.jet_nvtx[0] == 1) {
     _hm.h_tagging[_hm.s_ctag]->Fill(_jet.jet_ctag[0]);
     _hm.h_tagging[_hm.s_btag]->Fill(_jet.jet_btag[0]);
     _hm.h_tagging[_hm.jets_info]->Fill(1);
     _hm.h_tagging[_hm.jets_info]->Fill(5);
   }
-  if (_pfo.jet_nvtx_j2 == 1) {
+  if (_jet.jet_nvtx[1] == 1) {
     _hm.h_tagging[_hm.p_ctag]->Fill(_jet.jet_ctag[1]);
     _hm.h_tagging[_hm.p_btag]->Fill(_jet.jet_btag[1]);
     _hm.h_tagging[_hm.jets_info]->Fill(2);
@@ -325,13 +325,13 @@ void EventAnalyzer::AnalyzeReco(Long64_t entry)
   }
 
   // w/o Vertex
-  if (_pfo.jet_nvtx_j1 == 0) {
+  if (_jet.jet_nvtx[0] == 0) {
     _hm.h_tagging[_hm.t_ctag]->Fill(_jet.jet_ctag[0]);
     _hm.h_tagging[_hm.t_btag]->Fill(_jet.jet_btag[0]);
     _hm.h_tagging[_hm.jets_info]->Fill(1);
     _hm.h_tagging[_hm.jets_info]->Fill(3);
   }
-  if (_pfo.jet_nvtx_j2 == 0) {
+  if (_jet.jet_nvtx[1] == 0) {
     _hm.h_tagging[_hm.t_ctag]->Fill(_jet.jet_ctag[1]);
     _hm.h_tagging[_hm.t_btag]->Fill(_jet.jet_btag[1]);
     _hm.h_tagging[_hm.jets_info]->Fill(2);

--- a/NtupleProcessor/src/TreeReader.cc
+++ b/NtupleProcessor/src/TreeReader.cc
@@ -95,14 +95,16 @@ void TreeReader::InitializeJetReadTree(TTree *_hTree, Jet_QQbar & _data, Branch_
     _hTree->SetBranchAddress("sphericity_tensor", _data.sphericity_tensor, &_branch.b_sphericity_tensor);
 }
 
+void TreeReader::InitializeVTXReadTree(TTree *_hTree, VTX_QQbar & _data, Branch_QQbar & _branch)
+{
+    _hTree->SetBranchAddress("nvtx", &_data.nvtx, &_branch.b_nvtx);
+    _hTree->SetBranchAddress("vtx_d0", _data.vtx_d0, &_branch.b_vtx_d0);
+    _hTree->SetBranchAddress("vtx_z0", _data.vtx_z0, &_branch.b_vtx_z0);
+}
+
 void TreeReader::InitializePFOReadTree(TTree *_hTree, PFO_QQbar & _data, Branch_QQbar & _branch)
 {
     _hTree->SetBranchAddress("pfo_n", &_data.pfo_n, &_branch.b_pfo_n);
-    _hTree->SetBranchAddress("jet_nvtx", &_data.jet_nvtx, &_branch.b_jet_nvtx);
-    _hTree->SetBranchAddress("pfo_n_j1", &_data.pfo_n_j1, &_branch.b_pfo_n_j1);
-    _hTree->SetBranchAddress("jet_nvtx_j1", &_data.jet_nvtx_j1, &_branch.b_jet_nvtx_j1);
-    _hTree->SetBranchAddress("pfo_n_j2", &_data.pfo_n_j2, &_branch.b_pfo_n_j2);
-    _hTree->SetBranchAddress("jet_nvtx_j2", &_data.jet_nvtx_j2, &_branch.b_jet_nvtx_j2);
     _hTree->SetBranchAddress("pfo_match", _data.pfo_match, &_branch.b_pfo_match);
     _hTree->SetBranchAddress("pfo_truejet_pdg", _data.pfo_truejet_pdg, &_branch.b_pfo_truejet_pdg);
     _hTree->SetBranchAddress("pfo_truejet_type", _data.pfo_truejet_type, &_branch.b_pfo_truejet_type);

--- a/SSbarLibrary/include/TreeStructures.hh
+++ b/SSbarLibrary/include/TreeStructures.hh
@@ -13,6 +13,7 @@ const static int MAX_NPARTICLES = 1000;
 const static int NTRUE_JETS     = 5;
 const static int NQUARKS        = 2;
 const static int NJETS          = 2;
+const static int MAX_NVTX       = 2;
 
 struct MC_QQbar  {
 
@@ -87,13 +88,23 @@ struct Jet_QQbar  {
 
   public:
   // JET VARIABLES
-    Float_t truejet_E[NTRUE_JETS]    = {0};   Float_t jet_E[NJETS]    = {0};    Float_t y23 = 0;          Float_t major_thrust_value     = 0;   Float_t major_thrust_axis[3]     = {0};
-    Float_t truejet_px[NTRUE_JETS]   = {0};   Float_t jet_px[NJETS]   = {0};    Float_t y12 = 0;          Float_t minor_thrust_value     = 0;   Float_t minor_thrust_axis[3]     = {0};
-    Float_t truejet_py[NTRUE_JETS]   = {0};   Float_t jet_py[NJETS]   = {0};    Float_t d23 = 0;          Float_t principle_thrust_value = 0;   Float_t principle_thrust_axis[3] = {0};
-    Float_t truejet_pz[NTRUE_JETS]   = {0};   Float_t jet_pz[NJETS]   = {0};    Float_t d12 = 0;          Float_t sphericity = 0;               Float_t sphericity_tensor[3]     = {0};
-    Int_t   truejet_type[NTRUE_JETS] = {0};   Float_t jet_btag[NJETS] = {0};    Float_t oblateness = 0; 
-    Int_t   truejet_pdg[NTRUE_JETS]  = {0};   Float_t jet_ctag[NJETS] = {0};    Float_t aplanarity = 0;
+    Float_t truejet_E[NTRUE_JETS]    = {0};   Float_t jet_E[NJETS]    = {0};    Float_t jet_npfo[NJETS] = {0};    Float_t major_thrust_value     = 0;   Float_t major_thrust_axis[3]     = {0};
+    Float_t truejet_px[NTRUE_JETS]   = {0};   Float_t jet_px[NJETS]   = {0};    Float_t jet_nvtx[NJETS] = {0};    Float_t minor_thrust_value     = 0;   Float_t minor_thrust_axis[3]     = {0};
+    Float_t truejet_py[NTRUE_JETS]   = {0};   Float_t jet_py[NJETS]   = {0};    Float_t y23             = 0;      Float_t principle_thrust_value = 0;   Float_t principle_thrust_axis[3] = {0};
+    Float_t truejet_pz[NTRUE_JETS]   = {0};   Float_t jet_pz[NJETS]   = {0};    Float_t y12             = 0;      Float_t sphericity = 0;               Float_t sphericity_tensor[3]     = {0};
+    Int_t   truejet_type[NTRUE_JETS] = {0};   Float_t jet_btag[NJETS] = {0};    Float_t d23             = 0;      Float_t oblateness = 0; 
+    Int_t   truejet_pdg[NTRUE_JETS]  = {0};   Float_t jet_ctag[NJETS] = {0};    Float_t d12             = 0;      Float_t aplanarity = 0;
     
+};
+
+struct VTX_QQbar  {
+
+  public:
+  //VTX Variables
+    Int_t   nvtx = 0;
+    Float_t vtx_d0[NJETS][MAX_NVTX] = {0};
+    Float_t vtx_z0[NJETS][MAX_NVTX] = {0};
+
 };
 
 struct PFO_QQbar  {
@@ -102,10 +113,6 @@ struct PFO_QQbar  {
   // PFO VARIABLES
     Int_t   pfo_n       = 0;
     Int_t   jet_nvtx    = 0;
-    Int_t   pfo_n_j1    = 0;
-    Int_t   jet_nvtx_j1 = 0;
-    Int_t   pfo_n_j2    = 0;
-    Int_t   jet_nvtx_j2 = 0;
     Int_t   pfo_match[MAX_NPARTICLES] = {0};
     Int_t   pfo_truejet_pdg[MAX_NPARTICLES] = {0};
     Int_t   pfo_truejet_type[MAX_NPARTICLES] = {0};
@@ -372,12 +379,12 @@ struct Branch_QQbar  {
     TBranch        *b_principle_thrust_axis;   //!
     TBranch        *b_sphericity;   //!
     TBranch        *b_sphericity_tensor;   //!
-    TBranch        *b_pfo_n;   //!
+    TBranch        *b_jet_npfo;   //!
     TBranch        *b_jet_nvtx;   //!
-    TBranch        *b_pfo_n_j1;   //!
-    TBranch        *b_jet_nvtx_j1;   //!
-    TBranch        *b_pfo_n_j2;   //!
-    TBranch        *b_jet_nvtx_j2;   //!
+    TBranch        *b_vtx_d0;   //!
+    TBranch        *b_vtx_z0;   //!
+    TBranch        *b_pfo_n;   //!
+    TBranch        *b_nvtx;   //!
     TBranch        *b_pfo_match;   //!
     TBranch        *b_pfo_truejet_pdg;   //!
     TBranch        *b_pfo_truejet_type;   //!
@@ -571,6 +578,7 @@ struct Tree_Data {
   public:
     Float_t sum_jet_E = -100;
     Float_t jet_acol  = -100;
+    Float_t jet_theta_diff = -100;
 
     Int_t dEdx_pdg_match = -1;
 


### PR DESCRIPTION
## Vertex Updates

The update is mainly for including further vertex information in the list of trees.
I changed the list of variables in [QQbarAnalysis processor](https://github.com/yuichiok/QQbarAnalysis) thus this change had to be made. See [here](https://github.com/yuichiok/QQbarAnalysis/commit/85d7236bd091f2a80d9bacfcfac052cd0e823391) for the changes in the processor side. Therefore, all the files needed to be reprocessed for getting the full information and statistics.

Some of these variables are named the same way as before so be aware.
These changes are:
 - `_pfo.pfo_n_j1` and `_pfo.pfo_n_j2` are now converted to an array of `_jet.jet_npfo[2]`
 - `_pfo.jet_nvtx_j1` and `_pfo.jet_nvtx_j2` are now converted to an array of `_jet.jet_nvtx[2]`
 - The is new structure called `VTX_QQbar`
   - includes `_vtx.nvtx`: total number of vertices (`_jet.jet_nvtx[0]` + `_jet.jet_nvtx[1]`)
   - `_vtx.vtx_d0` and `_vtx.vtx_z0`

Things may need to be changed in your macros as well according to this update.
Let me know if your need any assistance.
Yuichi